### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Streamlit app is [implemented in only 150 lines of Python](https://github.co
 ![In-use Animation](https://github.com/streamlit/demo-face-gan/blob/master/GAN-demo.gif?raw=true "In-use Animation")
 
 ## How to run this demo
-The demo requires Python 3.6 (TensorFlow is not yet compatible with later versions). **We suggest creating a new virtual Python 3.6 environment**, then running:
+The demo requires Python 3.6 or 3.7 (The version of TensorFlow we specify in [requirements.txt](https://github.com/streamlit/demo-face-gan/blob/master/requirements.txt#L14) is supported in Python 3.8+). **We suggest creating a new virtual environment**, then running:
 
 ```
 git clone https://github.com/streamlit/demo-face-gan.git


### PR DESCRIPTION
Fixes #7, changing the README to indicate that Python 3.6 or Python 3.7 can be used with this demo, because we specify a TF version that is not (yet?) supported by Python 3.8.