### PR TITLE
Simplify run the demo

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-full
+
+RUN pyenv install 3.7.7 && \
+    pyenv global 3.7.7 && \
+    pip install --upgrade pip

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: pip install -r ./requirements.txt
+    command: streamlit run app.py
+
+ports:
+  - port: 8501
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Streamlit Demo: The Controllable GAN Face Generator
+# Streamlit Demo: The Controllable GAN Face Generator [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/streamlit/demo-face-gan)
 This project highlights Streamlit's new `hash_func` feature with an app that calls on TensorFlow to generate photorealistic faces, using Nvidia's [Progressive Growing of GANs](https://research.nvidia.com/publication/2017-10_Progressive-Growing-of) and Shaobo Guan's [Transparent Latent-space GAN](https://blog.insightdatascience.com/generating-custom-photo-realistic-faces-using-ai-d170b1b59255) method for tuning the output face's characteristics. For more information, check out the [tutorial on Towards Data Science](https://towardsdatascience.com/building-machine-learning-apps-with-streamlit-667cef3ff509). 
 
 The Streamlit app is [implemented in only 150 lines of Python](https://github.com/streamlit/demo-face-gan/blob/master/app.py) and demonstrates the wide new range of objects that can be used safely and efficiently in Streamlit apps with `hash_func`. 
@@ -14,6 +14,11 @@ cd demo-face-gan
 pip install -r requirements.txt
 streamlit run app.py
 ```
+
+Alternatively, you can use Gitpod to spin up a prebuilt dev environment running this example:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 
 ### Questions? Comments?
 


### PR DESCRIPTION
Hey 👋 
We have created an app called [Gitpod](https://www.gitpod.io) that allows to easily spin up dev environments on any git projects. I've seen many users opening gitpod environements on streamlit projects, so wanted to check it out my self. Pretty awesome experience so far 👍 .

This PR adds a [Gitpod](https://www.gitpod.io) config to this project, that allows anyone to spin up a fully initialized dev environment with the demo running. If you in addition to merging this PR also enable our GitHub app (https://github.com/apps/gitpod-io) on this project, users don't even have to wait for pip to install the dependencies, as Gitpod does that automatically in prebuilds.

You can try it out using this link: https://gitpod.io/#https://github.com/svenefftinge/demo-face-gan

We'd be happy to provide a similar config for your main project, so that contributors have an easier path. Let me know what you think.

This is what the experience looks like btw.:

<img width="1488" alt="Screenshot 2020-08-07 at 15 10 25" src="https://user-images.githubusercontent.com/372735/89649143-94cced80-d8c0-11ea-84c5-a8b91de19022.png">
 